### PR TITLE
Yangfan-0002: Add downstream service calls

### DIFF
--- a/src/main/java/io/github/yangfan/core/CoreApplication.java
+++ b/src/main/java/io/github/yangfan/core/CoreApplication.java
@@ -2,8 +2,10 @@ package io.github.yangfan.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class CoreApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/io/github/yangfan/core/CoreController.java
+++ b/src/main/java/io/github/yangfan/core/CoreController.java
@@ -1,0 +1,22 @@
+package io.github.yangfan.core;
+
+import io.github.yangfan.core.foo.FooBarResponse;
+import io.github.yangfan.core.foo.FooService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api")
+public class CoreController {
+
+    private final FooService fooService;
+
+    @GetMapping("users")
+    public FooBarResponse getFooBar(@RequestParam String id) {
+        return fooService.getFoo(id);
+    }
+}

--- a/src/main/java/io/github/yangfan/core/bar/BarResponse.java
+++ b/src/main/java/io/github/yangfan/core/bar/BarResponse.java
@@ -1,0 +1,9 @@
+package io.github.yangfan.core.bar;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class BarResponse {
+
+    String fieldA;
+}

--- a/src/main/java/io/github/yangfan/core/bar/BarService.java
+++ b/src/main/java/io/github/yangfan/core/bar/BarService.java
@@ -1,0 +1,11 @@
+package io.github.yangfan.core.bar;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BarService {
+
+    public BarResponse getBar() {
+        return BarResponse.of("todo");
+    }
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooBarResponse.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooBarResponse.java
@@ -1,0 +1,6 @@
+package io.github.yangfan.core.foo;
+
+
+public record FooBarResponse(String value) {
+
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooClient.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooClient.java
@@ -1,0 +1,33 @@
+package io.github.yangfan.core.foo;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        value = "foo-api",
+        url = "${foo-api:http://localhost:8090}",
+        configuration = FooClientConfiguration.class,
+        fallbackFactory = FooClient.FooClientFallBackFactory.class
+)
+public interface FooClient {
+
+    @GetMapping("/users/{userId}")
+    FooResponse getFoo(@PathVariable String userId);
+
+    @Slf4j
+    @Component
+    class FooClientFallBackFactory implements FallbackFactory<FooClient> {
+        @Override
+        public FooClient create(Throwable cause) {
+            log.info("Couldn't get foo response '{}'", cause.getLocalizedMessage());
+            return (userId) -> FooResponse.builder()
+                    .fieldA("a")
+                    .fieldB("b")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooClientConfiguration.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooClientConfiguration.java
@@ -1,0 +1,18 @@
+package io.github.yangfan.core.foo;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FooClientConfiguration  {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("foo", "bar");
+        };
+    }
+
+
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooResponse.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooResponse.java
@@ -1,0 +1,23 @@
+package io.github.yangfan.core.foo;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
+
+@Value
+@With
+@Builder
+public class FooResponse {
+
+    String fieldA;
+    String fieldB;
+    NestedObject nestedObject;
+
+    @Value
+    @With
+    @Builder
+    public static class NestedObject {
+        String nestedFieldA;
+        String nestedFieldB;
+    }
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooService.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooService.java
@@ -1,0 +1,17 @@
+package io.github.yangfan.core.foo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FooService {
+
+    private final FooClient fooClient;
+
+    public FooBarResponse getFoo(String userId) {
+        val fooResponse = fooClient.getFoo(userId);
+        return new FooBarResponse(String.format("%s, %s", fooResponse.getFieldA(), fooResponse.getFieldB()));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+application:
+  name: core-api
+# See https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/
+spring:
+  cloud:
+    openfeign:
+      circuitbreaker:
+        enabled: true
+
+foo:
+  url: http://localhost:8090

--- a/src/test/java/io/github/yangfan/core/CoreControllerTest.java
+++ b/src/test/java/io/github/yangfan/core/CoreControllerTest.java
@@ -1,0 +1,40 @@
+package io.github.yangfan.core;
+
+import io.github.yangfan.core.foo.FooBarResponse;
+import io.github.yangfan.core.foo.FooService;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CoreController.class)
+class CoreControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    FooService fooService;
+
+    @SneakyThrows
+    @Test
+    void getFooBar() {
+        given(fooService.getFoo(any())).willReturn(new FooBarResponse("cherubim"));
+
+        mockMvc.perform(get("/api/users").queryParam("id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.value").value("cherubim"));
+    }
+}

--- a/src/test/java/io/github/yangfan/core/foo/FooServiceTest.java
+++ b/src/test/java/io/github/yangfan/core/foo/FooServiceTest.java
@@ -1,0 +1,32 @@
+package io.github.yangfan.core.foo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class FooServiceTest {
+
+    @Mock
+    FooClient fooClient;
+
+    @InjectMocks
+    FooService fooService;
+
+    @Test
+    void getFoo() {
+        given(fooClient.getFoo(any())).willReturn(new FooResponse("a", "b", null));
+
+        var response = fooService.getFoo("coffee");
+
+        assertThat(response.value()).isEqualTo("a, b");
+    }
+}


### PR DESCRIPTION
* Add example call to downstream service (Let's pretend it's foo)

## Testing

Below should invoke a call to foo, and since the host doesn't exist, a fallback response is returned.
```
curl --location --request GET 'http://localhost:8080/api/users?id=1'

<== 200 Ok
{
    "value": "a, b"
}
```