### PR TITLE
Yangfan-0002: Add aop logging

### DIFF
--- a/src/main/java/io/github/yangfan/core/common/logging/LogConfig.java
+++ b/src/main/java/io/github/yangfan/core/common/logging/LogConfig.java
@@ -1,0 +1,64 @@
+package io.github.yangfan.core.common.logging;
+
+import com.google.common.collect.Maps;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Aspect
+@Slf4j
+@Configuration
+public class LogConfig {
+
+    private static final Map<Class<?>, Logger> LOGGERS = Maps.newConcurrentMap();
+
+    private Logger logger(JoinPoint joinPoint) {
+        val clazz = joinPoint.getTarget().getClass();
+        return LOGGERS.computeIfAbsent(clazz, LoggerFactory::getLogger);
+    }
+
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+    void restController() {
+        // empty method
+    }
+
+    @Before("restController()")
+    void beforeController(JoinPoint joinPoint) {
+        val log = logger(joinPoint);
+        val attributes = RequestContextHolder.currentRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes) {
+            val request = ((ServletRequestAttributes) attributes).getRequest();
+            val name = joinPoint.getSignature().getName();
+            log.info("{} {}{}",
+                    request.getMethod(),
+                    request.getServletPath(),
+                    Optional.ofNullable(request.getQueryString()).map(q -> "?" + q).orElse(""));
+            log.debug("{}() - args:  {}", name, joinPoint.getArgs());
+        }
+    }
+
+    @SneakyThrows
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint point) {
+        val start = System.currentTimeMillis();
+        val result = point.proceed();
+        val end = System.currentTimeMillis();
+        log.info("{}({}) -> {} - time taken: {}ms", point.getSignature().getName(), point.getArgs(), result, end - start);
+        return result;
+    }
+
+}

--- a/src/main/java/io/github/yangfan/core/common/logging/LogExecutionTime.java
+++ b/src/main/java/io/github/yangfan/core/common/logging/LogExecutionTime.java
@@ -1,0 +1,12 @@
+package io.github.yangfan.core.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+
+}

--- a/src/main/java/io/github/yangfan/core/foo/FooService.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooService.java
@@ -1,5 +1,6 @@
 package io.github.yangfan.core.foo;
 
+import io.github.yangfan.core.common.logging.LogExecutionTime;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ public class FooService {
 
     private final FooClient fooClient;
 
+    @LogExecutionTime
     public FooBarResponse getFoo(String userId) {
         val fooResponse = fooClient.getFoo(userId);
         return new FooBarResponse(String.format("%s, %s", fooResponse.getFieldA(), fooResponse.getFieldB()));


### PR DESCRIPTION
* Delegate logging using AOP
## Testing
```
2024-04-07T22:53:03.975-04:00  INFO 31440 --- [nio-8080-exec-2] io.github.yangfan.core.CoreController    : GET /api/users?id=1
2024-04-07T22:53:04.011-04:00  INFO 31440 --- [nio-8080-exec-2] y.c.f.FooClient$FooClientFallBackFactory : Couldn't get foo response 'Connection refused: no further information executing GET http://localhost:8090/users/1'
2024-04-07T22:53:04.012-04:00  INFO 31440 --- [nio-8080-exec-2] i.g.y.core.common.logging.LogConfig      : getFoo([1]) -> FooBarResponse[value=a, b] - time taken: 34ms
```