### PR TITLE
Yangfan-0003: Add trace & span id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
-application:
-  name: core-api
 # See https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/
 spring:
+  application:
+    name: yangfan-core-api
   cloud:
     openfeign:
       circuitbreaker:
@@ -9,3 +9,7 @@ spring:
 
 foo:
   url: http://localhost:8090
+
+logging:
+  pattern:
+    level: "%5p [${spring.application.name:}, %X{traceId:-}, %X{spanId:-}]"


### PR DESCRIPTION
* Add `io.micrometer`, was previously known as Spring Sleuth. This includes Trace & Span ID

## Testing
See logs for each request:
```
2024-04-10T21:04:58.448-04:00  INFO [core, 6617373a5a9928f27ebba2fa2ce681fc, 7ebba2fa2ce681fc] 3316 --- [nio-8080-exec-2] io.github.yangfan.core.CoreController    : GET /api/users?id=1
2024-04-10T21:04:58.492-04:00  INFO [core, 6617373a5a9928f27ebba2fa2ce681fc, 81fb8daac63346cf] 3316 --- [nio-8080-exec-2] y.c.f.FooClient$FooClientFallBackFactory : Couldn't get foo response 'Connection refused: no further information executing GET http://localhost:8090/users/1'
2024-04-10T21:04:58.495-04:00  INFO [core, 6617373a5a9928f27ebba2fa2ce681fc, 7ebba2fa2ce681fc] 3316 --- [nio-8080-exec-2] i.g.y.core.common.logging.LogConfig      : getFoo([1]) -> FooBarResponse[value=a, b] - time taken: 41ms
```