### PR TITLE
Update to multi-doc properties & feign logging

### DIFF
--- a/src/main/java/io/github/yangfan/core/foo/FooClientConfiguration.java
+++ b/src/main/java/io/github/yangfan/core/foo/FooClientConfiguration.java
@@ -1,13 +1,10 @@
 package io.github.yangfan.core.foo;
 
-import feign.RequestInterceptor;
-import feign.Response;
-import feign.RetryableException;
-import feign.Retryer;
+import feign.*;
 import feign.codec.ErrorDecoder;
-import io.github.yangfan.core.common.util.CommonUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.util.Optional;
 
@@ -21,6 +18,13 @@ public class FooClientConfiguration  {
         return requestTemplate -> {
             requestTemplate.header("foo", "bar");
         };
+    }
+
+    // Alternatively, we could bind using application.yml/properties
+    @Profile({"default", "local", "dev"})
+    @Bean
+    Logger.Level logLevel() {
+        return Logger.Level.FULL;
     }
 
     public class CustomDecoder implements ErrorDecoder {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,13 @@ foo:
 logging:
   pattern:
     level: "%5p [${spring.application.name:}, %X{traceId:-}, %X{spanId:-}]"
+
+---
+spring:
+  config:
+    activate:
+      on-profile: default,local,dev,test
+
+logging:
+  level:
+    io.github.yangfan.core.foo: DEBUG


### PR DESCRIPTION
* Use multi-doc style - application.properties or yml now have logging enabled based on profile
* Enable feign logging for local

## Testing
```
2024-04-11T21:17:07.518-04:00 DEBUG [core, 66188b93f8075b8541c0587fbf3deead, 7fdcfcea4a470016] 620 --- [pool-2-thread-1] io.github.yangfan.core.foo.FooClient     : [FooClient#getFoo] ---> GET http://localhost:8090/users/1 HTTP/1.1
2024-04-11T21:17:07.519-04:00 DEBUG [core, 66188b93f8075b8541c0587fbf3deead, 7fdcfcea4a470016] 620 --- [pool-2-thread-1] io.github.yangfan.core.foo.FooClient     : [FooClient#getFoo] foo: bar
2024-04-11T21:17:07.519-04:00 DEBUG [core, 66188b93f8075b8541c0587fbf3deead, 7fdcfcea4a470016] 620 --- [pool-2-thread-1] io.github.yangfan.core.foo.FooClient     : [FooClient#getFoo] ---> END HTTP (0-byte body)
2024-04-11T21:17:07.526-04:00 DEBUG [core, 66188b93f8075b8541c0587fbf3deead, 7fdcfcea4a470016] 620 --- [pool-2-thread-1] io.github.yangfan.core.foo.FooClient     : [FooClient#getFoo] <--- ERROR ConnectException: Connection refused: no further information (7ms)
2024-04-11T21:17:07.527-04:00 DEBUG [core, 66188b93f8075b8541c0587fbf3deead, 7fdcfcea4a470016] 620 --- [pool-2-thread-1] io.github.yangfan.core.foo.FooClient     : [FooClient#getFoo] java.net.ConnectException: Connection refused: no further information
```